### PR TITLE
fix: add back delay and remove comments

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -436,7 +436,7 @@ export default function Bridge() {
 
       // waitToFinalize is buggy, so add a delay to wait before finalizing tx (12 secs for testnet)
       // TODO: refactor as env var if withdraw window is changed
-      // await new Promise((resolve) => setTimeout(resolve, 12000));
+      await new Promise((resolve) => setTimeout(resolve, 12000));
 
       // Finalize the withdrawal
       const finalizeHash = await walletClientL1.finalizeWithdrawal({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -592,19 +592,16 @@ export default function Bridge() {
         await handleWithdrawWaitTillReadyToProve();
       }
 
-      // Prove the withdrawal tx on L2
-      // if (withdrawStatus === "ready_to_prove") {
-      //   await handleWithdrawProve();
-      // }
+      // Skip prove withdrawal tx step as it is manually triggered
 
+      // Wait until the prove tx is received
       if (withdrawStatus === "proving") {
         await handleWithdrawAddProveReceipt();
       }
 
-      // if (withdrawStatus === "proved") {
-      //   await handleWithdrawFinalize();
-      // }
+      // Skip finalize withdrawal tx step as it is manually triggered
 
+      // Wait until the finalize tx is received
       if (withdrawStatus === "finalizing") {
         await handleWithdrawAddFinalizeReceipt();
       }


### PR DESCRIPTION
## Summary

This a small PR to add back the wait timeout commented out in https://github.com/Snapchain/op-bridge-ui/pull/7

## Test plan

```
yarn dev
```